### PR TITLE
Added home section

### DIFF
--- a/software-portfolio/package-lock.json
+++ b/software-portfolio/package-lock.json
@@ -8,6 +8,7 @@
       "name": "software-portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.488.0",
         "next": "15.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -4000,6 +4001,14 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.488.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.488.0.tgz",
+      "integrity": "sha512-ronlL0MyKut4CEzBY/ai2ZpKPxyWO4jUqdAkm2GNK5Zn3Rj+swDz+3lvyAUXN0PNqPKIX6XM9Xadwz/skLs/pQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/software-portfolio/package.json
+++ b/software-portfolio/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "lucide-react": "^0.488.0",
+    "next": "15.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.0"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.0",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/software-portfolio/src/app/components/home/page.tsx
+++ b/software-portfolio/src/app/components/home/page.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Github, Linkedin } from "lucide-react";
+
+export default function Home() {
+  return (
+    <div className="w-1/2 flex flex-col items-center justify-center gap-8">
+        <h3 className="text-medium font-bold font-main">Hi, I'm Matthew</h3>
+        <h1 className="text-extraLarge font-semibold font-secondary">Software Engineer</h1>
+        <p className="text-small-medium font-secondary w-9/12 text-wrap text-center mt-12">
+        I am a software developer looking to establish myself in the tech industry
+        and improve my skill set
+        </p>
+        <div className="flex items-center justify-center gap-8">
+            <Github size={32} color="white" />
+            <Linkedin size={32} color="white" />
+        </div>
+        <div className="flex gap-4 items-center justify-center mt-4">
+            <button 
+                className="bg-secondary p-button text-medium font-semibold rounded-2xl border-2 border-secondary cursor-pointer font-main"
+            >
+            About Me
+            </button>
+            <button 
+                className="bg-primary p-button text-medium font-semibold rounded-2xl cursor-pointer border-2 border-secondary font-main"
+            >
+            Contact Me
+            </button>
+        </div>
+    </div>
+  );
+}

--- a/software-portfolio/src/app/globals.css
+++ b/software-portfolio/src/app/globals.css
@@ -21,9 +21,15 @@
   --color-secondary: #6884E9;
   --color-tertiary: #1B2836;
   --color-quaternary: #FFFFFF;
+
+  /* Padding */
+  --spacing-button: 0.5em;
+  --spacing-lg-button-horizontal: 2em;
+  --spacing-lg-button-vertical: 0.5em;
 }
 
 body {
   margin: 0;
   padding: 0;
+  color: white;
 }

--- a/software-portfolio/src/app/page.tsx
+++ b/software-portfolio/src/app/page.tsx
@@ -1,10 +1,12 @@
 import Image from "next/image";
 import Header from "./components/header/page";
+import Home from "./components/home/page";
 
-export default function Home() {
+export default function Root() {
   return (
-    <div className="flex flex-col items-center h-screen w-screen bg-primary">
+    <div className="flex flex-col items-center h-screen w-screen bg-primary gap-40">
       <Header />
+      <Home />
     </div>
   );
 }


### PR DESCRIPTION
# Purpose 
I added some text, icons, and buttons to style the home section of the portfolio.
# Changes
- Created home component
- Added Lucide icons for Github and LinkedIn
- Added text, icons, and buttons
- Added padding variables in the theme section of globals.css
- Added home component to root page
# Process
I created a home folder in the components folder and then installed Lucide to use it's Gihub and LinkedIn icons. I added text, icons, and buttons needed in the section. I also added some padding variables in globals.css for the buttons added and for a future large button. I imported the home component and added it to the root page.
# Testing
- NA
# Proof of Concept
![Capture d’écran (1852)](https://github.com/user-attachments/assets/1c156249-d568-40fc-bf27-225b3df58d10)